### PR TITLE
Fix: Capture Python function return type annotations

### DIFF
--- a/chapi-ast-python/src/main/kotlin/chapi/ast/pythonast/PythonFullIdentListener.kt
+++ b/chapi-ast-python/src/main/kotlin/chapi/ast/pythonast/PythonFullIdentListener.kt
@@ -97,6 +97,11 @@ class PythonFullIdentListener(var fileName: String) : PythonAstBaseListener() {
         if (ctx.typedargslist() != null) {
             currentFunction.Parameters = this.buildParameters(ctx.typedargslist())
         }
+
+        // Extract return type annotation if present (ARROW test)
+        if (ctx.ARROW() != null && ctx.test() != null) {
+            currentFunction.ReturnType = ctx.test().text
+        }
     }
 
     override fun exitFuncdef(ctx: PythonParser.FuncdefContext?) {

--- a/chapi-ast-python/src/test/kotlin/chapi/ast/pythonast/PythonFullIdentListenerTest.kt
+++ b/chapi-ast-python/src/test/kotlin/chapi/ast/pythonast/PythonFullIdentListenerTest.kt
@@ -109,6 +109,56 @@ def printinfo( name, age = 35):
     }
 
     @Test
+    internal fun shouldIdentifyFunctionReturnType() {
+        val code = """
+def add(a: int, b: int) -> int:
+    return a + b
+
+"""
+        val codeFile = PythonAnalyser().analysis(code, "")
+        val firstFunc = codeFile.DataStructures[0].Functions[0]
+        assertEquals(firstFunc.Name, "add")
+        assertEquals(firstFunc.ReturnType, "int")
+        assertEquals(firstFunc.Parameters.size, 2)
+        assertEquals(firstFunc.Parameters[0].TypeValue, "a")
+        assertEquals(firstFunc.Parameters[0].TypeType, "int")
+    }
+
+    @Test
+    internal fun shouldIdentifyComplexReturnType() {
+        val code = """
+from typing import List, Optional
+
+def get_items() -> List[str]:
+    return ["item1", "item2"]
+
+def find_user(id: int) -> Optional[User]:
+    return None
+
+"""
+        val codeFile = PythonAnalyser().analysis(code, "")
+        assertEquals(codeFile.DataStructures[0].Functions[0].Name, "get_items")
+        assertEquals(codeFile.DataStructures[0].Functions[0].ReturnType, "List[str]")
+
+        assertEquals(codeFile.DataStructures[0].Functions[1].Name, "find_user")
+        assertEquals(codeFile.DataStructures[0].Functions[1].ReturnType, "Optional[User]")
+    }
+
+    @Test
+    internal fun shouldIdentifyAsyncFunctionReturnType() {
+        val code = """
+async def fetch_data() -> dict:
+    return {}
+
+"""
+        val codeFile = PythonAnalyser().analysis(code, "")
+        val firstFunc = codeFile.DataStructures[0].Functions[0]
+        assertEquals(firstFunc.Name, "fetch_data")
+        assertEquals(firstFunc.ReturnType, "dict")
+        assertEquals(firstFunc.Modifiers[0], "async")
+    }
+
+    @Test
     internal fun shouldIdentifyClassAnnotation() {
         val code = """
 @decorator


### PR DESCRIPTION
## Description

This PR fixes issue #34 by adding support for capturing Python function return type annotations.

## Problem

Previously, Chapi's Python parser was not capturing return type annotations from Python functions, even though the ANTLR grammar already supported the syntax `(ARROW test)?` for return types.

## Solution

Added 5 lines of code to extract the return type from the function definition context:

```kotlin
// Extract return type annotation if present (ARROW test)
if (ctx.ARROW() != null && ctx.test() != null) {
    currentFunction.ReturnType = ctx.test().text
}
```

## Changes

### Modified Files
- `chapi-ast-python/src/main/kotlin/chapi/ast/pythonast/PythonFullIdentListener.kt`
  - Added return type extraction in `enterFuncdef()` method

### Test Coverage
Added 3 comprehensive test cases:

1. **shouldIdentifyFunctionReturnType**: Tests basic return type annotation
   ```python
   def add(a: int, b: int) -> int:
       return a + b
   ```

2. **shouldIdentifyComplexReturnType**: Tests complex generic types
   ```python
   def get_items() -> List[str]:
       return ["item1", "item2"]
   
   def find_user(id: int) -> Optional[User]:
       return None
   ```

3. **shouldIdentifyAsyncFunctionReturnType**: Tests async functions with return types
   ```python
   async def fetch_data() -> dict:
       return {}
   ```

## Test Results

All 25 tests in the Python AST module pass successfully:
- ✅ All existing tests continue to pass
- ✅ 3 new tests for return type annotations pass
- ✅ No regressions introduced

## Supported Return Type Formats

The fix now correctly captures:
- Simple types: `int`, `str`, `bool`, `dict`, `list`
- Generic types: `List[str]`, `Dict[str, int]`
- Optional types: `Optional[User]`, `Optional[Dict[str, str]]`
- Union types: `Union[int, str]`
- Custom types: `User`, `MyClass`
- Async function return types

## Example

```python
from typing import List, Optional

def calculate(x: int, y: int) -> int:
    return x + y

async def fetch_users() -> List[User]:
    return []

def find_by_id(id: int) -> Optional[User]:
    return None
```

After parsing with Chapi:
- `calculate` function will have `ReturnType = "int"`
- `fetch_users` function will have `ReturnType = "List[User]"` and `Modifiers = ["async"]`
- `find_by_id` function will have `ReturnType = "Optional[User]"`

## Compatibility

- ✅ Python 3.x type annotations
- ✅ Works with both regular and async functions
- ✅ Works with class methods
- ✅ Backward compatible - functions without return type annotations continue to work

Fixes #34

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Python AST parser now captures function return type annotations from type hints, including simple types, complex generics (List, Optional), and async functions.

* **Tests**
  * Added test coverage to verify accurate parsing of function return types across various Python function declarations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->