### PR TITLE
feat(typescript): upgrade to ANTLR v4 grammar with JSX/TSX support

### DIFF
--- a/chapi-ast-typescript/src/main/antlr/TypeScriptLexer.g4
+++ b/chapi-ast-typescript/src/main/antlr/TypeScriptLexer.g4
@@ -6,7 +6,7 @@
     added ECMAScript 6 support, cleared and transformed to the universal grammar.
  * Copyright (c) 2018 by Juan Alvarez (contributor -> ported to Go)
  * Copyright (c) 2019 by Andrii Artiushok (contributor -> added TypeScript support)
- * Copyright (c) 2022 by NumberFour AG (contributor -> overall restructuring and d.ts support)
+ * Copyright (c) 2024 by Andrew Leppard (www.wegrok.review)
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -30,204 +30,199 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+// $antlr-format alignTrailingComments true, columnLimit 150, maxEmptyLinesToKeep 1, reflowComments false, useTab false
+// $antlr-format allowShortRulesOnASingleLine true, allowShortBlocksOnASingleLine true, minEmptyLines 0, alignSemicolons ownLine
+// $antlr-format alignColons trailing, singleLineOverrulesHangingColon true, alignLexerCommands true, alignLabels true, alignTrailers true
+
 lexer grammar TypeScriptLexer;
 
-options {
-    superClass=TypeScriptLexerBase;
+channels {
+    ERROR
 }
 
+options {
+    superClass = TypeScriptLexerBase;
+}
 
-channels { ERROR, JSDOC }
+MultiLineComment  : '/*' .*? '*/'             -> channel(HIDDEN);
+SingleLineComment : '//' ~[\r\n\u2028\u2029]* -> channel(HIDDEN);
+RegularExpressionLiteral:
+    '/' RegularExpressionFirstChar RegularExpressionChar* {this.IsRegexPossible()}? '/' IdentifierPart*
+;
 
-JsxComment:                     '{/*' .*? '*/}'            -> channel(HIDDEN);
-JSDocComment:                   '/**' .*? '*/'             -> channel(JSDOC);
-MultiLineComment:               '/*'  .*? '*/'             -> channel(HIDDEN);
-SingleLineComment:              '//' ~[\r\n\u2028\u2029]*  -> channel(HIDDEN);
-RegularExpressionLiteral:       '/' RegularExpressionFirstChar RegularExpressionChar* {this.IsRegexPossible()}? '/' IdentifierPart*;
-
-OpenBracket:                    '[';
-CloseBracket:                   ']';
-OpenParen:                      '(';
-CloseParen:                     ')';
-OpenBrace:                      '{';
-CloseBrace:                     '}' {this.popModeIfInTamplateString();};
-SemiColon:                      ';';
-Comma:                          ',';
-Assign:                         '=';
-QuestionMark:                   '?';
-Colon:                          ':';
-Ellipsis:                       '...';
-Dot:                            '.';
-PlusPlus:                       '++';
-MinusMinus:                     '--';
-Plus:                           '+';
-Minus:                          '-';
-BitNot:                         '~';
-Not:                            '!';
-Multiply:                       '*';
-Divide:                         '/';
-Modulus:                        '%';
-//RightShiftArithmetic:           '>''>'; // split up to allow nested generics
-LeftShiftArithmetic:            '<<';
-//RightShiftLogical:              '>''>''>'; // split up to allow nested generics
-LessThan:                       '<';
-MoreThan:                       '>';
-LessThanEquals:                 '<=';
-GreaterThanEquals:              '>=';
-Equals_:                        '==';
-NotEquals:                      '!=';
-IdentityEquals:                 '===';
-IdentityNotEquals:              '!==';
-BitAnd:                         '&';
-BitXOr:                         '^';
-BitOr:                          '|';
-And:                            '&&';
-Or:                             '||';
-MultiplyAssign:                 '*=';
-DivideAssign:                   '/=';
-ModulusAssign:                  '%=';
-PlusAssign:                     '+=';
-MinusAssign:                    '-=';
-LeftShiftArithmeticAssign:      '<<=';
-RightShiftArithmeticAssign:     '>>=';
-RightShiftLogicalAssign:        '>>>=';
-BitAndAssign:                   '&=';
-BitXorAssign:                   '^=';
-BitOrAssign:                    '|=';
-ARROW:                          '=>';
-
-Hashtag:                        '#';
-Lodash:                         '_'; // lodash
-Dollar:                         '$'; // jquery
+OpenBracket                : '[';
+CloseBracket               : ']';
+OpenParen                  : '(';
+CloseParen                 : ')';
+OpenBrace                  : '{' {this.ProcessOpenBrace();};
+TemplateCloseBrace         :     {this.IsInTemplateString()}? '}' -> popMode;
+CloseBrace                 : '}' {this.ProcessCloseBrace();};
+SemiColon                  : ';';
+Comma                      : ',';
+Assign                     : '=';
+QuestionMark               : '?';
+QuestionMarkDot            : '?.';
+Colon                      : ':';
+Ellipsis                   : '...';
+Dot                        : '.';
+PlusPlus                   : '++';
+MinusMinus                 : '--';
+Plus                       : '+';
+Minus                      : '-';
+BitNot                     : '~';
+Not                        : '!';
+Multiply                   : '*';
+Divide                     : '/';
+Modulus                    : '%';
+Power                      : '**';
+NullCoalesce               : '??';
+Hashtag                    : '#';
+Dollar                     : '$';     // jQuery
+Lodash                     : '_';     // Lodash
+LeftShiftArithmetic        : '<<';
+// We can't match these in the lexer because it would cause issues when parsing
+// types like Map<string, Map<string, string>>
+// RightShiftArithmetic       : '>>';
+// RightShiftLogical          : '>>>';
+LessThan                   : '<';
+MoreThan                   : '>';
+LessThanEquals             : '<=';
+GreaterThanEquals          : '>=';
+Equals_                    : '==';
+NotEquals                  : '!=';
+IdentityEquals             : '===';
+IdentityNotEquals          : '!==';
+BitAnd                     : '&';
+BitXOr                     : '^';
+BitOr                      : '|';
+And                        : '&&';
+Or                         : '||';
+MultiplyAssign             : '*=';
+DivideAssign               : '/=';
+ModulusAssign              : '%=';
+PlusAssign                 : '+=';
+MinusAssign                : '-=';
+LeftShiftArithmeticAssign  : '<<=';
+RightShiftArithmeticAssign : '>>=';
+RightShiftLogicalAssign    : '>>>=';
+BitAndAssign               : '&=';
+BitXorAssign               : '^=';
+BitOrAssign                : '|=';
+PowerAssign                : '**=';
+NullishCoalescingAssign    : '??=';
+ARROW                      : '=>';
 
 /// Null Literals
 
-NullLiteral:                    'null';
-
-/// Undefined Literals
-
-UndefinedLiteral:               'undefined';
+NullLiteral: 'null';
 
 /// Boolean Literals
 
-BooleanLiteral:                 'true'
-              |                 'false';
+BooleanLiteral: 'true' | 'false';
 
 /// Numeric Literals
 
-DecimalLiteral:                 DecimalIntegerLiteral '.' [0-9] [0-9_]* ExponentPart?
-              |                 '.' [0-9] [0-9_]* ExponentPart?
-              |                 DecimalIntegerLiteral ExponentPart?
-              ;
+DecimalLiteral:
+    DecimalIntegerLiteral '.' [0-9] [0-9_]* ExponentPart?
+    | '.' [0-9] [0-9_]* ExponentPart?
+    | DecimalIntegerLiteral ExponentPart?
+;
 
 /// Numeric Literals
 
-HexIntegerLiteral:              '0' [xX] [0-9a-fA-F] HexDigit*;
-OctalIntegerLiteral:            '0' [0-7]+ {!this.IsStrictMode()}?;
-OctalIntegerLiteral2:           '0' [oO] [0-7] [_0-7]*;
-BinaryIntegerLiteral:           '0' [bB] [01] [_01]*;
+HexIntegerLiteral    : '0' [xX] [0-9a-fA-F] HexDigit*;
+OctalIntegerLiteral  : '0' [0-7]+ {!this.IsStrictMode()}?;
+OctalIntegerLiteral2 : '0' [oO] [0-7] [_0-7]*;
+BinaryIntegerLiteral : '0' [bB] [01] [_01]*;
 
-BigHexIntegerLiteral:           '0' [xX] [0-9a-fA-F] HexDigit* 'n';
-BigOctalIntegerLiteral:         '0' [oO] [0-7] [_0-7]* 'n';
-BigBinaryIntegerLiteral:        '0' [bB] [01] [_01]* 'n';
-BigDecimalIntegerLiteral:       DecimalIntegerLiteral 'n';
-
-/// Keywords
+BigHexIntegerLiteral     : '0' [xX] [0-9a-fA-F] HexDigit* 'n';
+BigOctalIntegerLiteral   : '0' [oO] [0-7] [_0-7]* 'n';
+BigBinaryIntegerLiteral  : '0' [bB] [01] [_01]* 'n';
+BigDecimalIntegerLiteral : DecimalIntegerLiteral 'n';
 
 /// Keywords
 
-Break:                          'break';
-Do:                             'do';
-Instanceof:                     'instanceof';
-Typeof:                         'typeof';
-Unique:                         'unique';
-Keyof:                          'keyof';
-Case:                           'case';
-Else:                           'else';
-New:                            'new';
-Target:                         'target';
-Var:                            'var';
-Catch:                          'catch';
-Finally:                        'finally';
-Return:                         'return';
-Void:                           'void';
-Continue:                       'continue';
-For:                            'for';
-Switch:                         'switch';
-While:                          'while';
-Debugger:                       'debugger';
-Function:                       'function';
-This:                           'this';
-With:                           'with';
-Default:                        'default';
-If:                             'if';
-Throw:                          'throw';
-Delete:                         'delete';
-In:                             'in';
-Try:                            'try';
-As:                             'as';
-From:                           'from';
-ReadOnly:                       'readonly';
-Async:                          'async';
-Await:                          'await';
+Break      : 'break';
+Do         : 'do';
+Instanceof : 'instanceof';
+Typeof     : 'typeof';
+Case       : 'case';
+Else       : 'else';
+New        : 'new';
+Var        : 'var';
+Catch      : 'catch';
+Finally    : 'finally';
+Return     : 'return';
+Void       : 'void';
+Continue   : 'continue';
+For        : 'for';
+Switch     : 'switch';
+While      : 'while';
+Debugger   : 'debugger';
+Function_  : 'function';
+This       : 'this';
+With       : 'with';
+Default    : 'default';
+If         : 'if';
+Throw      : 'throw';
+Delete     : 'delete';
+In         : 'in';
+Try        : 'try';
+As         : 'as';
+From       : 'from';
+ReadOnly   : 'readonly';
+Async      : 'async';
+Await      : 'await';
+Yield      : 'yield';
+YieldStar  : 'yield*';
 
 /// Future Reserved Words
 
-Class:                          'class';
-Enum:                           'enum';
-Extends:                        'extends';
-Super:                          'super';
-Const:                          'const';
-Export:                         'export';
-Import:                         'import';
+Class   : 'class';
+Enum    : 'enum';
+Extends : 'extends';
+Super   : 'super';
+Const   : 'const';
+Export  : 'export';
+Import  : 'import';
 
 /// The following tokens are also considered to be FutureReservedWords
 /// when parsing strict mode
 
-Implements:                     'implements' ;
-Let:                            'let' ;
-Private:                        'private';
-Public:                         'public' ;
-Interface:                      'interface' ;
-Package:                        'package' ;
-Protected:                      'protected' ;
-Static:                         'static' ;
-Yield:                          'yield' ;
-
+Implements : 'implements';
+Let        : 'let';
+Private    : 'private';
+Public     : 'public';
+Interface  : 'interface';
+Package    : 'package';
+Protected  : 'protected';
+Static     : 'static';
 
 //keywords:
+Any        : 'any';
+Number     : 'number';
+Never      : 'never';
+Boolean    : 'boolean';
+String     : 'string';
+Unique     : 'unique';
+Symbol     : 'symbol';
+Undefined  : 'undefined';
+Object     : 'object';
 
-Any : 'any';
-Number: 'number';
-Boolean: 'boolean';
-String: 'string';
-Symbol: 'symbol';
-Of: 'of';
+Of      : 'of';
+KeyOf   : 'keyof';
 
+TypeAlias: 'type';
 
-TypeAlias : 'type';
-
-Get: 'get';
-Set: 'set';
-
-Constructor: 'constructor';
-Namespace: 'namespace';
-Global: 'global';
-Require: 'require';
-Module: 'module';
-Declare: 'declare';
+Constructor : 'constructor';
+Namespace   : 'namespace';
+Require     : 'require';
+Module      : 'module';
+Declare     : 'declare';
 
 Abstract: 'abstract';
 
 Is: 'is';
-
-Infer: 'infer';
-
-Never: 'never';
-
-Unknown: 'unknown';
-
-Asserts: 'asserts';
 
 //
 // Ext.2 Additions to 1.8: Decorators
@@ -236,240 +231,87 @@ At: '@';
 
 /// Identifier Names and Identifiers
 
-Identifier:                     IdentifierStart IdentifierPart*;
+Identifier: IdentifierStart IdentifierPart*;
 
 /// String Literals
-StringLiteral:                 ('"' DoubleStringCharacter* '"'
-             |                  '\'' SingleStringCharacter* '\'')
-             ;
+StringLiteral:
+    ('"' DoubleStringCharacter* '"' | '\'' SingleStringCharacter* '\'') {this.ProcessStringLiteral();}
+;
 
+BackTick: '`' {this.IncreaseTemplateDepth();} -> pushMode(TEMPLATE);
 
-BackTick:                       '`' {this.IncreaseTemplateDepth();} -> pushMode(TEMPLATE);
+WhiteSpaces: [\t\u000B\u000C\u0020\u00A0]+ -> channel(HIDDEN);
 
-WhiteSpaces:                    [\t\u000B\u000C\u0020\u00A0]+ -> channel(HIDDEN);
-
-LineTerminator:                 [\r\n\u2028\u2029] -> channel(HIDDEN);
+LineTerminator: [\r\n\u2028\u2029] -> channel(HIDDEN);
 
 /// Comments
 
-
-HtmlComment:                    '<!--' .*? '-->' -> channel(HIDDEN);
-CDataComment:                   '<![CDATA[' .*? ']]>' -> channel(HIDDEN);
-UnexpectedCharacter:            . -> channel(ERROR);
+HtmlComment         : '<!--' .*? '-->'      -> channel(HIDDEN);
+CDataComment        : '<![CDATA[' .*? ']]>' -> channel(HIDDEN);
+UnexpectedCharacter : .                     -> channel(ERROR);
 
 mode TEMPLATE;
 
-BackTickInside:                 '`' {this.DecreaseTemplateDepth();} -> type(BackTick), popMode;
-TemplateStringStartExpression:  '${' -> pushMode(DEFAULT_MODE);
-TemplateStringAtom:             EscapeTick | ~[`];
+TemplateStringEscapeAtom      : '\\' .;
+BackTickInside                : '`'  {this.DecreaseTemplateDepth();} -> type(BackTick), popMode;
+TemplateStringStartExpression : '${' {this.StartTemplateString();} -> pushMode(DEFAULT_MODE);
+TemplateStringAtom            : ~[`\\];
 
 // Fragment rules
 
-fragment EscapeTick
-    : '\u005C\u0060'
-    ;
+fragment DoubleStringCharacter: ~["\\\r\n] | '\\' EscapeSequence | LineContinuation;
 
-fragment DoubleStringCharacter
-    : ~["\\\r\n]
-    | '\\' EscapeSequence
-    | LineContinuation
-    ;
+fragment SingleStringCharacter: ~['\\\r\n] | '\\' EscapeSequence | LineContinuation;
 
-fragment SingleStringCharacter
-    : ~['\\\r\n]
-    | '\\' EscapeSequence
-    | LineContinuation
-    ;
-
-fragment EscapeSequence
-    : CharacterEscapeSequence
+fragment EscapeSequence:
+    CharacterEscapeSequence
     | '0' // no digit ahead! TODO
     | HexEscapeSequence
     | UnicodeEscapeSequence
     | ExtendedUnicodeEscapeSequence
-    ;
+;
 
-fragment CharacterEscapeSequence
-    : SingleEscapeCharacter
-    | NonEscapeCharacter
-    ;
+fragment CharacterEscapeSequence: SingleEscapeCharacter | NonEscapeCharacter;
 
-fragment HexEscapeSequence
-    : 'x' HexDigit HexDigit
-    ;
+fragment HexEscapeSequence: 'x' HexDigit HexDigit;
 
-fragment UnicodeEscapeSequence
-    : 'u' HexDigit HexDigit HexDigit HexDigit
-    ;
+fragment UnicodeEscapeSequence:
+    'u' HexDigit HexDigit HexDigit HexDigit
+    | 'u' '{' HexDigit HexDigit+ '}'
+;
 
-fragment ExtendedUnicodeEscapeSequence
-    : 'u' '{' HexDigit+ '}'
-    ;
+fragment ExtendedUnicodeEscapeSequence: 'u' '{' HexDigit+ '}';
 
-fragment SingleEscapeCharacter
-    : ['"\\bfnrtv]
-    ;
+fragment SingleEscapeCharacter: ['"\\bfnrtv];
 
-fragment NonEscapeCharacter
-    : ~['"\\bfnrtv0-9xu\r\n]
-    ;
+fragment NonEscapeCharacter: ~['"\\bfnrtv0-9xu\r\n];
 
-fragment EscapeCharacter
-    : SingleEscapeCharacter
-    | [0-9]
-    | [xu]
-    ;
+fragment EscapeCharacter: SingleEscapeCharacter | [0-9] | [xu];
 
-fragment LineContinuation
-    : '\\' [\r\n\u2028\u2029]
-    ;
+fragment LineContinuation: '\\' [\r\n\u2028\u2029]+;
 
-fragment HexDigit
-    : [0-9a-fA-F]
-    ;
+fragment HexDigit: [_0-9a-fA-F];
 
-fragment DecimalIntegerLiteral
-    : '0'
-    | [1-9] [0-9_]*
-    ;
+fragment DecimalIntegerLiteral: '0' | [1-9] [0-9_]*;
 
-fragment ExponentPart
-    : [eE] [+-]? [0-9]+
-    ;
+fragment ExponentPart: [eE] [+-]? [0-9_]+;
 
-fragment IdentifierPart
-    : IdentifierStart
-    | [\p{Mn}]
-    | [\p{Nd}]
-    | [\p{Pc}]
-    | '\u200C'
-    | '\u200D'
-    ;
+fragment IdentifierPart: IdentifierStart | [\p{Mn}] | [\p{Nd}] | [\p{Pc}] | '\u200C' | '\u200D';
 
-fragment IdentifierStart
-    : [\p{L}]
-    | [$_]
-    | '\\' UnicodeEscapeSequence
-    ;
+fragment IdentifierStart: [\p{L}] | [$_] | '\\' UnicodeEscapeSequence;
 
-fragment RegularExpressionFirstChar
-    : ~[*\r\n\u2028\u2029\\/[]
+fragment RegularExpressionFirstChar:
+    ~[*\r\n\u2028\u2029\\/[]
     | RegularExpressionBackslashSequence
     | '[' RegularExpressionClassChar* ']'
-    ;
+;
 
-fragment RegularExpressionChar
-    : ~[\r\n\u2028\u2029\\/[]
+fragment RegularExpressionChar:
+    ~[\r\n\u2028\u2029\\/[]
     | RegularExpressionBackslashSequence
     | '[' RegularExpressionClassChar* ']'
-    ;
+;
 
-fragment RegularExpressionClassChar
-    : ~[\r\n\u2028\u2029\]\\]
-    | RegularExpressionBackslashSequence
-    ;
+fragment RegularExpressionClassChar: ~[\r\n\u2028\u2029\]\\] | RegularExpressionBackslashSequence;
 
-fragment RegularExpressionBackslashSequence
-    : '\\' ~[\r\n\u2028\u2029]
-    ;
-
-//
-// html tag declarations
-//
-mode TAG;
-
-TagOpen
-    : LessThan -> pushMode(TAG)
-    ;
-TagClose
-    : MoreThan -> popMode
-    ;
-
-TagSlashClose
-    : '/>' -> popMode
-    ;
-
-TagSlash
-    : Divide
-    ;
-
-TagName
-    : TagNameStartChar TagNameChar*
-    ;
-
-// an attribute value may have spaces b/t the '=' and the value
-AttributeValue
-    : [ ]* Attribute -> popMode
-    ;
-
-Attribute
-    : DoubleQuoteString
-    | SingleQuoteString
-    | AttributeChar
-    | HexChars
-    | DecChars
-    ;
-
-// Fragment rules
-fragment AttributeChar
-    : '-'
-    | '_'
-    | '.'
-    | '/'
-    | '+'
-    | ','
-    | '?'
-    | '='
-    | ':'
-    | ';'
-    | '#'
-    | [0-9a-zA-Z]
-    ;
-
-fragment AttributeChars
-    : AttributeChar+ ' '?
-    ;
-
-fragment HexChars
-    : '#' [0-9a-fA-F]+
-    ;
-
-fragment DecChars
-    : [0-9]+ '%'?
-    ;
-
-
-fragment
-TagNameStartChar
-    :   [:a-zA-Z]
-    |   '\u2070'..'\u218F'
-    |   '\u2C00'..'\u2FEF'
-    |   '\u3001'..'\uD7FF'
-    |   '\uF900'..'\uFDCF'
-    |   '\uFDF0'..'\uFFFD'
-    ;
-
-fragment
-TagNameChar
-    : TagNameStartChar
-    | '-'
-    | '_'
-    | '.'
-    | Digit
-    |   '\u00B7'
-    |   '\u0300'..'\u036F'
-    |   '\u203F'..'\u2040'
-    ;
-
-fragment DoubleQuoteString
-    : '"' ~[<"]* '"'
-    ;
-fragment SingleQuoteString
-    : '\'' ~[<']* '\''
-    ;
-
-fragment
-Digit
-    : [0-9]
-    ;
-
+fragment RegularExpressionBackslashSequence: '\\' ~[\r\n\u2028\u2029];

--- a/chapi-ast-typescript/src/main/java/chapi/ast/antlr/TypeScriptLexerBase.java
+++ b/chapi-ast-typescript/src/main/java/chapi/ast/antlr/TypeScriptLexerBase.java
@@ -127,6 +127,11 @@ public abstract class TypeScriptLexerBase extends Lexer
         this.templateDepth--;
     }
 
+    protected void StartTemplateString() {
+        // Called when starting a template expression ${...}
+        // This helps track that we're in a template context
+    }
+
     /**
      * Returns {@code true} if the lexer can match a regex literal.
      */

--- a/chapi-ast-typescript/src/main/java/chapi/ast/antlr/TypeScriptParserBase.java
+++ b/chapi-ast-typescript/src/main/java/chapi/ast/antlr/TypeScriptParserBase.java
@@ -64,7 +64,42 @@ public abstract class TypeScriptParserBase extends Parser
 
     protected boolean notOpenBraceAndNotFunction() {
         int nextTokenType = _input.LT(1).getType();
-        return nextTokenType != TypeScriptParser.OpenBrace && nextTokenType != TypeScriptParser.Function;
+        return nextTokenType != TypeScriptParser.OpenBrace && nextTokenType != TypeScriptParser.Function_;
+    }
+
+    protected boolean notOpenBraceAndNotFunctionAndNotInterface() {
+        int nextTokenType = _input.LT(1).getType();
+        return nextTokenType != TypeScriptParser.OpenBrace && 
+               nextTokenType != TypeScriptParser.Function_ &&
+               nextTokenType != TypeScriptParser.Interface;
+    }
+
+    protected boolean notOpenBraceAndNotFunctionAndNotInterfaceAndNotReturn() {
+        int nextTokenType = _input.LT(1).getType();
+        return nextTokenType != TypeScriptParser.OpenBrace &&
+               nextTokenType != TypeScriptParser.Function_ &&
+               nextTokenType != TypeScriptParser.Interface &&
+               nextTokenType != TypeScriptParser.Return;
+    }
+
+    protected boolean notOpenBraceAndNotStatementKeyword() {
+        int t = _input.LT(1).getType();
+        return t != TypeScriptParser.OpenBrace &&
+               t != TypeScriptParser.Function_ &&
+               t != TypeScriptParser.Interface &&
+               t != TypeScriptParser.Return &&
+               t != TypeScriptParser.Try &&
+               t != TypeScriptParser.Throw &&
+               t != TypeScriptParser.If &&
+               t != TypeScriptParser.For &&
+               t != TypeScriptParser.While &&
+               t != TypeScriptParser.Do &&
+               t != TypeScriptParser.Switch &&
+               t != TypeScriptParser.Break &&
+               t != TypeScriptParser.Continue &&
+               t != TypeScriptParser.Class &&
+               t != TypeScriptParser.Import &&
+               t != TypeScriptParser.Export;
     }
 
     protected boolean closeBrace() {


### PR DESCRIPTION
## Summary

- Upgrade TypeScript parser to ANTLR v4 grammar (based on Andrew Leppard's grammar from wegrok.review)
- Add comprehensive JSX/TSX support for React component parsing
- Improve compatibility with modern TypeScript syntax features

## Key Changes

### Grammar Updates (TypeScriptParser.g4)

**JSX/TSX Support:**
- Add `htmlElement`, `htmlContent`, `htmlTagName`, `htmlAttribute` rules for JSX parsing
- Support full JSX elements, self-closing tags, and fragments (`<></>`)
- Implement tag name matching with `pushHtmlTagName`/`popHtmlTagName` predicates
- Handle JSX expressions `{expression}` and spread attributes `{...props}`

**TypeScript Syntax Improvements:**
- Support definite assignment assertion (`!`) in class properties: `prop!: Type`
- Add trailing comma support in type parameter lists
- Improve arrow function body parsing (prioritize block body over single expression)
- Add optional call expression support (`obj?.method()`)
- Support generic call expressions (`func<T>(args)`)

**Export Statement Fixes:**
- Reorder export rules to correctly parse `export default identifier;`
- Remove conflicting `Export?` from `sourceElement` rule
- Add `ExportElementDirectly` for exported declarations

**Compatibility Layer:**
- Add aliases for backward compatibility (`typeRef` → `type_`, `parameterizedTypeRef`)
- Support both old and new import syntax patterns
- Maintain interface body compatibility

### Listener Updates (TypeScriptFullIdentListener.kt)

- Adapt to new grammar rule names and structures
- Fix duplicate export recording in `enterExportElementDirectly`
- Improve arrow function detection with parent context traversal
- Fix `ParenthesizedExpressionContext` handling for function calls vs JSX returns
- Add support for `IsReturnHtml` flag for React components

### Parser Base Updates (TypeScriptParserBase.java)

- Add `pushHtmlTagName`/`popHtmlTagName` for JSX tag matching
- Add `notOpenBraceAndNotStatementKeyword` predicate
- Add `lineTerminatorAhead` and `closeBrace` helper methods

## Test Plan

- [x] All 133 TypeScript tests pass (130 passed, 3 skipped)
- [x] JSX/TSX parsing tests pass (shouldIdentTsx, shouldIdentReactComponents, etc.)
- [x] Export statement tests pass (shouldIdentExportFunctions, shouldSetExportConstantsToContainer)
- [x] Arrow function tests pass (arrow_in_arrow, shouldSupportNestedFunc)
- [x] Class property tests pass (classPropCheckIssue with `!` assertion)
- [x] Function call identification tests pass (correctFunctionCallName)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced TypeScript generic and type parameter support
  * Improved JSX/TSX element parsing and handling
  * Expanded import/export statement recognition and processing
  * Enhanced template literal and string handling

* **Bug Fixes**
  * Improved null-safety in type resolution to prevent parsing errors
  * Better handling of optional type references and contexts

* **Improvements**
  * Refined decorator and annotation extraction for class declarations
  * Standardized token naming and grammar structure for better parsing consistency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->