### PR TITLE
feat(domain): add structured call semantics to CodeCall

### DIFF
--- a/chapi-domain/src/test/kotlin/chapi/domain/core/CodeCallTest.kt
+++ b/chapi-domain/src/test/kotlin/chapi/domain/core/CodeCallTest.kt
@@ -63,4 +63,138 @@ internal class CodeCallTest {
     internal fun testEquals() {
         assertEquals(CodeCall(FunctionName = "get"), CodeCall(FunctionName = "get"))
     }
+
+    // ==================== Tests for New Structured Fields (Since 2.4.0) ====================
+
+    @Test
+    fun `should handle TypeScript promise chain`() {
+        // axios.get("/api").then(res => res.data).catch(handleError)
+        val call = CodeCall(
+            ReceiverExpr = "axios",
+            FunctionName = "get",
+            Chain = listOf("then", "catch"),
+            Parameters = listOf(CodeProperty(TypeValue = "\"/api\"", TypeType = "string"))
+        )
+
+        assertEquals("axios", call.ReceiverExpr)
+        assertEquals("get", call.FunctionName)
+        assertEquals(listOf("then", "catch"), call.Chain)
+        assertTrue(call.isChainedCall())
+        assertEquals(3, call.chainLength())
+        assertEquals("catch", call.lastMethodName())
+        assertEquals(listOf("get", "then", "catch"), call.allMethodNames())
+        assertEquals("axios.get().then().catch()", call.buildChainString())
+    }
+
+    @Test
+    fun `should handle optional chaining call`() {
+        // user?.profile?.getName()
+        val call = CodeCall(
+            ReceiverExpr = "user?.profile",
+            FunctionName = "getName",
+            IsOptional = true
+        )
+
+        assertEquals("user?.profile", call.ReceiverExpr)
+        assertEquals("getName", call.FunctionName)
+        assertTrue(call.IsOptional)
+        assertFalse(call.isChainedCall())
+    }
+
+    @Test
+    fun `should handle Go fluent API chain`() {
+        // v1.Group("/api").GET("/users", handler)
+        val call = CodeCall(
+            ReceiverExpr = "v1",
+            OriginNodeName = "v1",  // backward compatibility
+            FunctionName = "Group",
+            Chain = listOf("GET"),
+            ReceiverType = CodeTypeRef.simple("RouterGroup")
+        )
+
+        assertEquals("v1", call.ReceiverExpr)
+        assertEquals("v1", call.OriginNodeName)
+        assertEquals("Group", call.FunctionName)
+        assertEquals(listOf("GET"), call.Chain)
+        assertEquals("RouterGroup", call.ReceiverType?.name)
+        assertEquals("v1.Group().GET()", call.buildChainString())
+    }
+
+    @Test
+    fun `should handle Rust async chain`() {
+        // client.get(url).send().await?.json::<T>().await?
+        val call = CodeCall(
+            ReceiverExpr = "client",
+            FunctionName = "get",
+            Chain = listOf("send", "json"),
+            ReceiverType = CodeTypeRef.simple("reqwest::Client"),
+            ReturnType = CodeTypeRef.generic("Result", CodeTypeRef.simple("T"), CodeTypeRef.simple("Error"))
+        )
+
+        assertEquals("client", call.ReceiverExpr)
+        assertEquals("get", call.FunctionName)
+        assertEquals(listOf("send", "json"), call.Chain)
+        assertEquals("reqwest::Client", call.ReceiverType?.name)
+        assertEquals(TypeRefKind.GENERIC, call.ReturnType?.kind)
+    }
+
+    @Test
+    fun `should handle simple function call without receiver`() {
+        // println("hello")
+        val call = CodeCall(
+            FunctionName = "println",
+            Parameters = listOf(CodeProperty(TypeValue = "\"hello\"", TypeType = "string"))
+        )
+
+        assertEquals("", call.ReceiverExpr)
+        assertEquals("println", call.FunctionName)
+        assertFalse(call.isChainedCall())
+        assertEquals(1, call.chainLength())
+        assertEquals("println", call.lastMethodName())
+    }
+
+    @Test
+    fun `should handle chain with arguments`() {
+        // builder.setName("Alice").setAge(30).build()
+        val call = CodeCall(
+            ReceiverExpr = "builder",
+            FunctionName = "setName",
+            Parameters = listOf(CodeProperty(TypeValue = "\"Alice\"", TypeType = "String")),
+            Chain = listOf("setAge", "build"),
+            ChainArguments = listOf(
+                listOf(CodeProperty(TypeValue = "30", TypeType = "int")),
+                listOf()  // build() has no arguments
+            )
+        )
+
+        assertEquals("builder", call.ReceiverExpr)
+        assertEquals("setName", call.FunctionName)
+        assertEquals(listOf("setAge", "build"), call.Chain)
+        assertEquals(2, call.ChainArguments.size)
+        assertEquals("30", call.ChainArguments[0][0].TypeValue)
+        assertTrue(call.ChainArguments[1].isEmpty())
+    }
+
+    @Test
+    fun `should fall back to NodeName when ReceiverExpr is empty`() {
+        // Legacy format: using NodeName instead of ReceiverExpr
+        val call = CodeCall(
+            NodeName = "System.out",
+            FunctionName = "println"
+        )
+
+        assertEquals("", call.ReceiverExpr)
+        assertEquals("System.out", call.NodeName)
+        // buildChainString should use NodeName as fallback
+        assertEquals("System.out.println()", call.buildChainString())
+    }
+
+    @Test
+    fun `should handle all method names for non-chained call`() {
+        val call = CodeCall(FunctionName = "doSomething")
+
+        assertEquals(listOf("doSomething"), call.allMethodNames())
+        assertEquals("doSomething", call.lastMethodName())
+        assertFalse(call.isChainedCall())
+    }
 }


### PR DESCRIPTION
## Summary

- Add structured fields to `CodeCall` for better cross-language call representation (Issue #41 Section E)
- New fields: `ReceiverExpr`, `ReceiverType`, `IsOptional`, `Chain`, `ChainArguments`, `ReturnType`
- Add helper methods for chain analysis: `allMethodNames()`, `isChainedCall()`, `lastMethodName()`, `chainLength()`, `buildChainString()`

## Motivation

This addresses the call semantics issues described in #41:
- TS promise chains like `axios.get().then().catch()` can now be properly represented
- Optional chaining (`obj?.method()`) is now trackable via `IsOptional`
- Go/Rust fluent APIs can preserve the full call chain structure
- Receiver types can be tracked for better type analysis

## Changes

| Field | Type | Description |
|-------|------|-------------|
| `ReceiverExpr` | `String` | Original receiver expression text |
| `ReceiverType` | `CodeTypeRef?` | Resolved type of the receiver |
| `IsOptional` | `Boolean` | Whether this is optional chaining (TS `?.()`) |
| `Chain` | `List<String>` | Method names in chained calls |
| `ChainArguments` | `List<List<CodeProperty>>` | Arguments for each chain method |
| `ReturnType` | `CodeTypeRef?` | Return type of the call |

## Backward Compatibility

- All new fields have default values
- Legacy fields `NodeName` and `OriginNodeName` are preserved with documentation
- Existing JSON serialization is not affected

## Test plan

- [x] Added 9 new test cases covering TypeScript, Go, Rust patterns
- [x] All 16 tests pass
- [x] No linter errors

Refs #41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced support for method chaining and fluent API calls with improved receiver and return type tracking
  * Added optional chaining syntax detection capability
  * New utility methods for analyzing and navigating chained method calls

* **Tests**
  * Added comprehensive test coverage for chained methods, optional chaining, and fluent APIs across multiple programming languages

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->