### PR TITLE
feat(domain): add TopLevelScope for unified top-level declarations

### DIFF
--- a/chapi-domain/src/main/kotlin/chapi/domain/core/CodeDataStruct.kt
+++ b/chapi-domain/src/main/kotlin/chapi/domain/core/CodeDataStruct.kt
@@ -75,6 +75,43 @@ data class CodeDataStruct(
             this.NodeName.lowercase().contains("utils")
     }
 
+    /**
+     * Returns true if this DataStruct is a legacy top-level container.
+     *
+     * Legacy top-level containers were used before [TopLevelScope] to hold
+     * file-level/module-level declarations that don't belong to any class.
+     *
+     * A DataStruct is considered a legacy top-level container if:
+     * - NodeName is "default" (common in TypeScript/JavaScript, Python)
+     * - NodeName is empty (some parsers leave it blank for top-level)
+     * - Type is DEFAULT
+     * - NodeName starts with lowercase (heuristic for Rust module files like "main", "lib")
+     *
+     * @since 2.4.0
+     * @see TopLevelScope
+     */
+    @Since("2.4.0")
+    fun isLegacyTopLevelContainer(): Boolean {
+        // Explicit "default" name or empty name
+        if (NodeName == "default" || NodeName.isEmpty()) {
+            return true
+        }
+
+        // Type is explicitly DEFAULT
+        if (Type == DataStructType.DEFAULT) {
+            return true
+        }
+
+        // Heuristic: Rust/Go module files often start with lowercase (e.g., "main", "file_mod")
+        // while actual classes/structs start with uppercase
+        val firstChar = NodeName.firstOrNull()
+        if (firstChar != null && firstChar.isLowerCase() && Type == DataStructType.OBJECT) {
+            return true
+        }
+
+        return false
+    }
+
     fun setMethodsFromMap(methodMap: MutableMap<String, CodeFunction>) {
         this.Functions = methodMap.values.toList()
     }

--- a/chapi-domain/src/main/kotlin/chapi/domain/core/TopLevelScope.kt
+++ b/chapi-domain/src/main/kotlin/chapi/domain/core/TopLevelScope.kt
@@ -152,13 +152,14 @@ data class TopLevelScope(
     var Extension: Map<String, String> = mapOf(),
 ) {
     /**
-     * Returns true if this scope has any declarations.
+     * Returns true if this scope has no declarations.
      */
-    fun isEmpty(): Boolean = Functions.isEmpty() && Fields.isEmpty() && 
-                             Exports.isEmpty() && TypeAliases.isEmpty()
+    fun isEmpty(): Boolean = Functions.isEmpty() && Fields.isEmpty() &&
+                             Exports.isEmpty() && TypeAliases.isEmpty() &&
+                             Extension.isEmpty()
 
     /**
-     * Returns true if this scope has any declarations.
+     * Returns true if this scope has any declarations (i.e., is not empty).
      */
     fun isNotEmpty(): Boolean = !isEmpty()
 

--- a/chapi-domain/src/test/kotlin/chapi/domain/core/TopLevelScopeTest.kt
+++ b/chapi-domain/src/test/kotlin/chapi/domain/core/TopLevelScopeTest.kt
@@ -16,6 +16,17 @@ internal class TopLevelScopeTest {
     }
 
     @Test
+    fun `TopLevelScope with only Extension should not be empty`() {
+        val scope = TopLevelScope(
+            Extension = mapOf("__all__" to "[\"foo\", \"bar\"]")
+        )
+        assertFalse(scope.isEmpty())
+        assertTrue(scope.isNotEmpty())
+        // declarationCount doesn't include Extension
+        assertEquals(0, scope.declarationCount())
+    }
+
+    @Test
     fun `TopLevelScope with functions should not be empty`() {
         val scope = TopLevelScope(
             Functions = listOf(
@@ -418,6 +429,60 @@ internal class TopLevelScopeTest {
         assertNotNull(container.TopLevel)
         assertEquals(1, container.DataStructures.size)
         assertEquals("RealClass", container.DataStructures[0].NodeName)
+    }
+
+    // ==================== CodeDataStruct.isLegacyTopLevelContainer Tests ====================
+
+    @Test
+    fun `isLegacyTopLevelContainer should detect default node`() {
+        val defaultNode = CodeDataStruct(NodeName = "default")
+        assertTrue(defaultNode.isLegacyTopLevelContainer())
+    }
+
+    @Test
+    fun `isLegacyTopLevelContainer should detect empty node name`() {
+        val emptyNode = CodeDataStruct(NodeName = "")
+        assertTrue(emptyNode.isLegacyTopLevelContainer())
+    }
+
+    @Test
+    fun `isLegacyTopLevelContainer should detect DEFAULT type`() {
+        val defaultTypeNode = CodeDataStruct(
+            NodeName = "something",
+            Type = DataStructType.DEFAULT
+        )
+        assertTrue(defaultTypeNode.isLegacyTopLevelContainer())
+    }
+
+    @Test
+    fun `isLegacyTopLevelContainer should detect lowercase OBJECT nodes`() {
+        // Rust module files like "main.rs" create OBJECT nodes with lowercase names
+        val rustMainNode = CodeDataStruct(
+            NodeName = "main",
+            Type = DataStructType.OBJECT
+        )
+        assertTrue(rustMainNode.isLegacyTopLevelContainer())
+    }
+
+    @Test
+    fun `isLegacyTopLevelContainer should not flag actual classes`() {
+        val actualClass = CodeDataStruct(
+            NodeName = "UserService",
+            Type = DataStructType.CLASS
+        )
+        assertFalse(actualClass.isLegacyTopLevelContainer())
+
+        val actualInterface = CodeDataStruct(
+            NodeName = "Repository",
+            Type = DataStructType.INTERFACE
+        )
+        assertFalse(actualInterface.isLegacyTopLevelContainer())
+
+        val actualStruct = CodeDataStruct(
+            NodeName = "Config",
+            Type = DataStructType.STRUCT
+        )
+        assertFalse(actualStruct.isLegacyTopLevelContainer())
     }
 
     // ==================== Backward Compatibility Tests ====================


### PR DESCRIPTION
## Summary

- Add `TopLevelScope` structure to replace the legacy `default` node pattern (Issue #41 Section B)
- Add `CodeTypeAlias` for type alias declarations across languages
- Add helper methods to `CodeContainer` for backward-compatible access

## Motivation

The previous convention of using `CodeDataStruct(NodeName="default")` for top-level declarations had several problems:
- Inconsistent across languages (TypeScript used "default", Go sometimes left empty, Rust used filename)
- Mixed semantics with actual class/struct definitions
- No clear indication of file-scope vs class-scope declarations

## New Types

### TopLevelScope
Container for file-level/module-level declarations:
- `Functions`: top-level/free functions
- `Fields`: module-level variables, constants, static items
- `Exports`: export declarations (TypeScript/JavaScript)
- `TypeAliases`: type alias definitions
- `Extension`: language-specific constructs

### CodeTypeAlias
Represents type aliases:
- `Name`: alias name
- `OriginalType`: original type text
- `TypeRef`: structured type reference
- `TypeParameters`: generic parameters

## CodeContainer Additions

| Method | Description |
|--------|-------------|
| `TopLevel` | New field for structured top-level declarations |
| `getTopLevelFunctions()` | Combines TopLevel and legacy default nodes |
| `getTopLevelFields()` | Combines multiple sources |
| `getTopLevelExports()` | Returns exports from TopLevel |
| `getActualDataStructures()` | Excludes default nodes |
| `hasTopLevelDeclarations()` | Checks for any top-level content |
| `migrateDefaultNodesToTopLevel()` | Migration helper for parsers |

## Migration Path

**Before (legacy):**
```kotlin
CodeContainer(
    DataStructures = listOf(
        CodeDataStruct(NodeName = "default", Functions = [...], Fields = [...])
    )
)
```

**After (with TopLevelScope):**
```kotlin
CodeContainer(
    TopLevel = TopLevelScope(Functions = [...], Fields = [...]),
    DataStructures = listOf(/* only actual classes/structs */)
)
```

## Backward Compatibility

- `TopLevel` is nullable with default `null`
- `getTopLevelFunctions()` falls back to checking `default` nodes
- Existing JSON serialization is not affected
- Parsers can gradually migrate using `migrateDefaultNodesToTopLevel()`

## Test plan

- [x] Added 21 test cases covering TypeScript, Python, Go, Rust patterns
- [x] Migration tests for default node conversion
- [x] Backward compatibility tests
- [x] All tests pass
- [x] No linter errors

Refs #41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Explicit support for file-level declarations (functions, fields, exports, type aliases) across languages.
  * Backward-compatible retrieval and migration utilities to transition legacy file-scope data into the new model.
  * Improved detection of legacy file-level containers to aid safe migration.

* **Tests**
  * Comprehensive test suite validating top-level declarations and migration across TypeScript, Python, Go, and Rust.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->