### PR TITLE
feat(ast): implement Issue #41 P0 parser adaptations

### DIFF
--- a/chapi-ast-go/src/test/kotlin/chapi/ast/goast/GoAnalyserTest.kt
+++ b/chapi-ast-go/src/test/kotlin/chapi/ast/goast/GoAnalyserTest.kt
@@ -30,7 +30,9 @@ func main() {
                         CodeCall(
                             NodeName = "fmt",
                             FunctionName = "Println",
-                            Parameters = listOf(CodeProperty(TypeValue = "hello world", TypeType = "string"))
+                            Parameters = listOf(CodeProperty(TypeValue = "hello world", TypeType = "string")),
+                            // New structured field (Issue #41)
+                            ReceiverExpr = "fmt"
                         )
                     ),
                 )

--- a/chapi-ast-rust/src/main/kotlin/chapi/ast/rustast/RustAstBaseListener.kt
+++ b/chapi-ast-rust/src/main/kotlin/chapi/ast/rustast/RustAstBaseListener.kt
@@ -58,6 +58,14 @@ open class RustAstBaseListener(private val fileName: String) : RustParserBaseLis
         val allStruct = structMap.values
         DataStructures = (buildDedicatedStructs() + allStruct)
         Imports = imports
+        
+        // New: populate TopLevel structure (Issue #41 - P0 adaptation)
+        if (individualFunctions.isNotEmpty() || individualFields.isNotEmpty()) {
+            TopLevel = TopLevelScope(
+                Functions = individualFunctions,
+                Fields = individualFields
+            )
+        }
     }
 
     override fun enterModule(ctx: RustParser.ModuleContext?) {

--- a/chapi-ast-rust/src/main/kotlin/chapi/ast/rustast/RustFullIdentListener.kt
+++ b/chapi-ast-rust/src/main/kotlin/chapi/ast/rustast/RustFullIdentListener.kt
@@ -49,7 +49,9 @@ class RustFullIdentListener(fileName: String) : RustAstBaseListener(fileName) {
             FunctionName = pureFuncName,
             OriginNodeName = nodeName,
             Parameters = buildParameters(ctx?.callParams()),
-            Position = buildPosition(ctx ?: return)
+            Position = buildPosition(ctx ?: return),
+            // New structured fields (Issue #41)
+            ReceiverExpr = nodeName
         )
     }
 
@@ -102,7 +104,9 @@ class RustFullIdentListener(fileName: String) : RustAstBaseListener(fileName) {
             OriginNodeName = instanceVar.ifEmpty { nodeName },
             FunctionName = functionName,
             Parameters = buildParameters(ctx?.callParams()),
-            Position = buildPosition(ctx ?: return)
+            Position = buildPosition(ctx ?: return),
+            // New structured fields (Issue #41)
+            ReceiverExpr = instanceVar.ifEmpty { nodeName }
         )
     }
 

--- a/chapi-ast-typescript/src/test/kotlin/chapi/ast/typescriptast/TypeScriptCallTest.kt
+++ b/chapi-ast-typescript/src/test/kotlin/chapi/ast/typescriptast/TypeScriptCallTest.kt
@@ -4,6 +4,8 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 internal class TypeScriptCallTest {
 
@@ -23,5 +25,80 @@ function testNew() {
         assertEquals(functionCalls[0].FunctionName, "display")
         assertEquals(functionCalls[0].NodeName, "Employee")
         assertEquals(functionCalls[0].Parameters.size, 0)
+    }
+
+    /**
+     * Issue #41 - Test TopLevel structure is populated for TypeScript
+     */
+    @Test
+    fun shouldPopulateTopLevelStructure() {
+        val code = """
+const API_URL = "https://api.example.com";
+
+export function fetchData() {
+    return fetch(API_URL);
+}
+
+export const handler = async () => {
+    return "result";
+};
+"""
+        val codeFile = TypeScriptAnalyser().analysis(code, "test.ts")
+
+        // New: TopLevel should be populated
+        assertNotNull(codeFile.TopLevel, "TopLevel should be populated")
+        assertTrue(codeFile.TopLevel!!.Functions.isNotEmpty(), "TopLevel should have functions")
+        assertTrue(codeFile.TopLevel!!.Fields.isNotEmpty(), "TopLevel should have fields")
+        
+        // Should have fetchData and handler functions
+        val functionNames = codeFile.TopLevel!!.Functions.map { it.Name }
+        assertTrue(functionNames.contains("fetchData"), "TopLevel should contain fetchData function")
+        assertTrue(functionNames.contains("handler"), "TopLevel should contain handler function")
+        
+        // Should have API_URL field
+        val fieldNames = codeFile.TopLevel!!.Fields.map { it.TypeKey }
+        assertTrue(fieldNames.contains("API_URL"), "TopLevel should contain API_URL field")
+    }
+
+    /**
+     * Issue #41 - Test structured import/export with new fields
+     */
+    @Test
+    fun shouldPopulateStructuredImportFields() {
+        val code = """
+import { foo, bar as baz } from "module";
+import * as utils from "./utils";
+import React from "react";
+"""
+        val codeFile = TypeScriptAnalyser().analysis(code, "test.ts")
+
+        val namedImport = codeFile.Imports.find { it.Source == "module" }
+        assertNotNull(namedImport)
+        assertEquals(chapi.domain.core.ImportKind.NAMED, namedImport.Kind)
+        assertTrue(namedImport.Specifiers.isNotEmpty(), "Named import should have specifiers")
+        
+        val namespaceImport = codeFile.Imports.find { it.Source.contains("utils") }
+        assertNotNull(namespaceImport)
+        assertEquals(chapi.domain.core.ImportKind.NAMESPACE, namespaceImport.Kind)
+        assertEquals("utils", namespaceImport.NamespaceName)
+        
+        val defaultImport = codeFile.Imports.find { it.Source == "react" }
+        assertNotNull(defaultImport)
+        assertEquals(chapi.domain.core.ImportKind.DEFAULT, defaultImport.Kind)
+        assertEquals("React", defaultImport.DefaultName)
+    }
+
+    /**
+     * Issue #41 - Test CodeContainer new fields (Language, Kind)
+     */
+    @Test
+    fun shouldPopulateContainerMetadata() {
+        val code = """
+export const x = 1;
+"""
+        val codeFile = TypeScriptAnalyser().analysis(code, "test.ts")
+
+        assertEquals("typescript", codeFile.Language)
+        assertEquals(chapi.domain.core.ContainerKind.MODULE, codeFile.Kind)
     }
 }


### PR DESCRIPTION
## Summary

Implements P0 parser adaptations for Issue #41 (chapi-domain core model improvements):

- **TypeScript Parser**: Populate `TopLevel` structure alongside legacy `default` node for backward compatibility; add structured call chain parsing with `ReceiverExpr`, `Chain`, `ChainArguments`, `IsOptional` fields
- **Go Parser**: Populate `TopLevel` structure for package-level functions; add `ReceiverExpr` to `CodeCall`
- **Rust Parser**: Populate `TopLevel` structure for free functions; add `ReceiverExpr` to `CodeCall`
- **Tests**: Add regression tests covering new structured fields

## Related Issue

Closes #41 (partial - P0 parser adaptations)

## Changes

| File | Description |
|------|-------------|
| `TypeScriptFullIdentListener.kt` | Add `TopLevel` population, structured chain call parsing with `ChainCallInfo` |
| `GoFullIdentListener.kt` | Add `TopLevel` population, `ReceiverExpr` field |
| `RustAstBaseListener.kt` | Add `TopLevel` population |
| `RustFullIdentListener.kt` | Add `ReceiverExpr` field |
| `TypeScriptCallTest.kt` | Add tests for TopLevel, Import/Export, Container metadata |
| `GoAnalyserTest.kt` | Update test to include new `ReceiverExpr` field |

## Test Plan

- [x] All existing TypeScript parser tests pass
- [x] All existing Go parser tests pass
- [x] All existing Rust parser tests pass
- [x] New regression tests for structured fields pass
- [x] Full test suite passes (`./gradlew test`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added receiver expression tracking for function calls across Go, Rust, and TypeScript analyzers
  * Introduced top-level scope support to capture module-level functions and fields
  * Enhanced structured representation for chained method calls and import/export handling in TypeScript

* **Tests**
  * Added comprehensive test coverage for top-level structure population, import/export fields, and container metadata

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->